### PR TITLE
Fix CultureNotFoundException under InvariantGlobalization=true

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@ Given a version number MAJOR.MINOR.PATCH, increment:
 
 ## [Unreleased]
 
+## [0.2.1] - 2026-06-10
+### Fixed
+- support for apps built with InvariantGlobalization=true: replaced `new CultureInfo("en-US")` with `CultureInfo.InvariantCulture` in Request.cs (Access-Time header) and made all other request-path formatting/parsing culture-invariant (StarkDate/StarkDateTime, EndToEndId/ReturnId timestamps, Checks date parsing, Url query values), which previously threw `CultureNotFoundException` on .NET 6+ invariant-mode runtimes; output is byte-identical to the previous en-US formatting
+
 ## [0.2.0] - 2026-03-03
 ### Added
 - Put method

--- a/Starkcore/Starkcore.csproj
+++ b/Starkcore/Starkcore.csproj
@@ -2,8 +2,8 @@
 
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
-    <ReleaseVersion>0.2.0</ReleaseVersion>
-    <Version>0.2.0</Version>
+    <ReleaseVersion>0.2.1</ReleaseVersion>
+    <Version>0.2.1</Version>
     <LangVersion>10.0</LangVersion>
     <PackageId>starkcore</PackageId>
     <Authors>Starkcore</Authors>

--- a/Starkcore/utils/Checks.cs
+++ b/Starkcore/utils/Checks.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Globalization;
 using System.Collections.Generic;
 using EllipticCurve;
 using StarkCore;
@@ -51,7 +52,7 @@ public static class Checks
 
     public static DateTime CheckDateTime(string data)
     {
-        return DateTime.Parse(data);
+        return DateTime.Parse(data, CultureInfo.InvariantCulture);
     }
 
     public static DateTime? CheckNullableDateTime(string data)

--- a/Starkcore/utils/DateTime.cs
+++ b/Starkcore/utils/DateTime.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Globalization;
 
 
 namespace StarkCore.Utils
@@ -17,7 +18,7 @@ namespace StarkCore.Utils
             if (Value == null)
                 return null;
             DateTime value = (DateTime)Value;
-            return value.ToString("yyyy-MM-dd");
+            return value.ToString("yyyy-MM-dd", CultureInfo.InvariantCulture);
         }
     }
 
@@ -35,7 +36,7 @@ namespace StarkCore.Utils
             if (Value == null)
                 return null;
             DateTime value = (DateTime)Value;
-            return value.ToUniversalTime().ToString("yyyy-MM-ddTHH:mm:ss.ffffff") + "+00:00";
+            return value.ToUniversalTime().ToString("yyyy-MM-ddTHH:mm:ss.ffffff", CultureInfo.InvariantCulture) + "+00:00";
         }
     }
 }

--- a/Starkcore/utils/EndToEndId.cs
+++ b/Starkcore/utils/EndToEndId.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Linq;
+using System.Globalization;
 using System.Collections.Generic;
 
 
@@ -16,7 +17,7 @@ namespace StarkCore.Utils
             string endToEndID = "E";
 
             endToEndID += bankCode;
-            endToEndID += DateTime.Now.ToString(@"yyyyMMddhhmm");
+            endToEndID += DateTime.Now.ToString(@"yyyyMMddhhmm", CultureInfo.InvariantCulture);
 
             foreach (int i in range)
             {

--- a/Starkcore/utils/Request.cs
+++ b/Starkcore/utils/Request.cs
@@ -75,7 +75,7 @@ namespace StarkCore.Utils
                 url += Url.Encode(query);
             }
 
-            string accessTime = DateTime.UtcNow.Subtract(new DateTime(1970, 1, 1)).TotalSeconds.ToString(new CultureInfo("en-US"));
+            string accessTime = DateTime.UtcNow.Subtract(new DateTime(1970, 1, 1)).TotalSeconds.ToString(CultureInfo.InvariantCulture);
             string body = "";
             if (payload != null)
             {

--- a/Starkcore/utils/ReturnId.cs
+++ b/Starkcore/utils/ReturnId.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Linq;
+using System.Globalization;
 using System.Collections.Generic;
 
 
@@ -16,7 +17,7 @@ namespace StarkCore.Utils
             string ReturnID = "D";
 
             ReturnID += bankCode;
-            ReturnID += DateTime.Now.ToString(@"yyyyMMddhhmm");
+            ReturnID += DateTime.Now.ToString(@"yyyyMMddhhmm", CultureInfo.InvariantCulture);
 
             foreach (int i in range)
             {

--- a/Starkcore/utils/Url.cs
+++ b/Starkcore/utils/Url.cs
@@ -1,5 +1,6 @@
 ﻿using System.Collections;
 using System.Collections.Generic;
+using System.Globalization;
 
 
 namespace StarkCore.Utils
@@ -26,7 +27,7 @@ namespace StarkCore.Utils
                 }
                 else
                 {
-                    value = entry.Value.ToString();
+                    value = System.Convert.ToString(entry.Value, CultureInfo.InvariantCulture);
                 }
 
                 queryStringList.Add(entry.Key + "=" + System.Web.HttpUtility.UrlEncode(value));

--- a/tests/testCultureSafety.cs
+++ b/tests/testCultureSafety.cs
@@ -1,0 +1,100 @@
+using Xunit;
+using System;
+using System.Globalization;
+using System.Linq;
+using StarkCore.Utils;
+
+
+namespace StarkCoreTests
+{
+    // These tests guard the request-path string formatting against machine-locale
+    // dependence and against CultureNotFoundException under InvariantGlobalization=true
+    // (PredefinedCulturesOnly), where instantiating any named culture like
+    // new CultureInfo("en-US") throws. They require no credentials or network access.
+    public class TestCultureSafety
+    {
+        // Builds the Access-Time header value exactly as Request.Fetch does.
+        private static string BuildAccessTime(DateTime utcNow)
+        {
+            return utcNow.Subtract(new DateTime(1970, 1, 1)).TotalSeconds.ToString(CultureInfo.InvariantCulture);
+        }
+
+        [Fact]
+        public void AccessTimeIsAsciiDigitsWithSingleDotAndNeedsNoNamedCulture()
+        {
+            // building the value must not require constructing any named culture:
+            // the expression below uses only CultureInfo.InvariantCulture, which is
+            // always available, including under InvariantGlobalization=true
+            string accessTime = BuildAccessTime(DateTime.UtcNow);
+
+            Assert.NotEmpty(accessTime);
+            Assert.True(
+                accessTime.All(c => (c >= '0' && c <= '9') || c == '.'),
+                $"Access-Time '{accessTime}' contains characters other than ASCII digits and '.'"
+            );
+            Assert.True(
+                accessTime.Count(c => c == '.') <= 1,
+                $"Access-Time '{accessTime}' contains more than one '.' separator"
+            );
+            Assert.True(char.IsDigit(accessTime[0]), $"Access-Time '{accessTime}' must start with a digit");
+        }
+
+        [Theory]
+        [InlineData("de-DE")]
+        [InlineData("ru-RU")]
+        [InlineData("ar-SA")]
+        [InlineData("tr-TR")]
+        public void AccessTimeIsByteIdenticalToEnUsUnderHostileCurrentCultures(string hostileCultureName)
+        {
+            CultureInfo original = CultureInfo.CurrentCulture;
+            try
+            {
+                CultureInfo.CurrentCulture = new CultureInfo(hostileCultureName);
+
+                var seededRandom = new Random(20260610);
+                for (int i = 0; i < 1000; i++)
+                {
+                    double timestamp = seededRandom.NextDouble() * 4102444800d; // 0 .. year 2100
+                    string invariant = timestamp.ToString(CultureInfo.InvariantCulture);
+                    string enUsReference = timestamp.ToString(new CultureInfo("en-US"));
+
+                    Assert.Equal(enUsReference, invariant);
+                }
+
+                string accessTimeNow = BuildAccessTime(DateTime.UtcNow);
+                Assert.True(
+                    accessTimeNow.All(c => (c >= '0' && c <= '9') || c == '.'),
+                    $"Under {hostileCultureName}, Access-Time '{accessTimeNow}' is not ASCII digits + '.'"
+                );
+            }
+            finally
+            {
+                CultureInfo.CurrentCulture = original;
+            }
+        }
+
+        [Theory]
+        [InlineData("de-DE")]
+        [InlineData("ru-RU")]
+        [InlineData("ar-SA")] // default calendar is Um Al Qura: CurrentCulture-based formatting would emit Hijri years
+        [InlineData("tr-TR")]
+        public void StarkDateAndStarkDateTimeAreGregorianUnderHostileCurrentCultures(string hostileCultureName)
+        {
+            CultureInfo original = CultureInfo.CurrentCulture;
+            try
+            {
+                CultureInfo.CurrentCulture = new CultureInfo(hostileCultureName);
+
+                var date = new DateTime(2026, 6, 10, 0, 0, 0, DateTimeKind.Utc);
+                Assert.Equal("2026-06-10", new StarkDate(date).ToString());
+
+                var dateTime = new DateTime(2026, 6, 10, 13, 45, 30, DateTimeKind.Utc).AddTicks(1234560);
+                Assert.Equal("2026-06-10T13:45:30.123456+00:00", new StarkDateTime(dateTime).ToString());
+            }
+            finally
+            {
+                CultureInfo.CurrentCulture = original;
+            }
+        }
+    }
+}

--- a/tests/tests.csproj
+++ b/tests/tests.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFrameworks>netcoreapp3.1;net8.0</TargetFrameworks>
     <ReleaseVersion>0.2.0</ReleaseVersion>
   </PropertyGroup>
 


### PR DESCRIPTION
## Problem

Apps built with `InvariantGlobalization=true` (common for trimmed/containerized .NET 6+ deployments; on .NET 6+ this also enables `PredefinedCulturesOnly`, making `new CultureInfo("en-US")` throw) cannot use any Stark SDK built on starkcore: `Request.Fetch` formats the `Access-Time` header with `new CultureInfo("en-US")` (`Starkcore/utils/Request.cs:78`), which throws `CultureNotFoundException` in invariant mode. The header is built before any network I/O, so **every** request fails immediately.

## Fix

- `Request.cs`: format the Access-Time unix timestamp with `CultureInfo.InvariantCulture`.
- Audited the rest of the request path and made it culture-invariant too, since `CurrentCulture`-sensitive formatting can corrupt request values on some machines even without invariant mode:
  - `DateTime.cs` (`StarkDate`/`StarkDateTime`): under e.g. ar-SA the default Um Al Qura calendar would emit Hijri years into `yyyy-MM-dd` strings.
  - `EndToEndId.cs` / `ReturnId.cs`: same calendar sensitivity for the `yyyyMMddhhmm` segments.
  - `Checks.cs`: `DateTime.Parse` now uses `InvariantCulture` (was `CurrentCulture`-dependent).
  - `Url.cs`: query-value `ToString()` → `Convert.ToString(value, InvariantCulture)` so numeric query params can't pick up a `,` decimal separator.
- Bumped the package version to 0.2.1 and updated the CHANGELOG.

`Subresource.ToString()` (debug-only, not on the request path) was deliberately left unchanged.

## Why the output is byte-identical to en-US

- A `double`'s digit sequence comes from the culture-independent shortest-round-trip algorithm; the culture contributes only `NumberDecimalSeparator` and `NegativeSign`, which are `.` and `-` for both en-US and InvariantCulture (fixed CLDR data on every platform).
- Verified empirically: with `CultureInfo.CurrentCulture` forced to de-DE, fr-FR, ru-RU, ar-SA, fa-IR, tr-TR and hi-IN (locales with `,` or `٫` separators), en-US vs InvariantCulture formatting stayed byte-identical across 100k random timestamps per locale — 0 mismatches — even though implicit CurrentCulture formatting under those locales produces different bytes.
- The change is strictly *more* deterministic than the status quo: on Windows, `new CultureInfo("en-US")` is created with `UseUserOverride=true`, so a user's regional-settings customizations could in principle change the emitted separator today; `CultureInfo.InvariantCulture` can never be overridden.

## Tests

New `tests/testCultureSafety.cs` (no credentials or network needed):

- Access-Time shape: ASCII digits + at most one `.`, buildable without any named culture.
- Byte-identity to the en-US reference under hostile `CurrentCulture`s (de-DE, ru-RU, ar-SA, tr-TR), 1000 seeded random timestamps each.
- Gregorian-calendar guards for `StarkDate`/`StarkDateTime` under the same locales (these fail against the unpatched `DateTime.cs` under ar-SA).

The test project is multi-targeted to `netcoreapp3.1;net8.0` so the suite also runs on hosts without the 3.1 runtime (e.g. arm64 Macs). All 9 new tests pass; the solution builds with 0 errors. Pre-existing `TestRest*` tests require sandbox credentials and were not run.

Downstream verification: a locally-packed 0.2.1 was consumed by starkbank/sdk-dotnet with a new net8.0 `InvariantGlobalization=true` integration test project — the test fails with `CultureNotFoundException` against 0.2.0 and passes against this patch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)